### PR TITLE
Add all MP AI annotation from Buhake work

### DIFF
--- a/examples/helidon-car-booking-portable-ext/pom.xml
+++ b/examples/helidon-car-booking-portable-ext/pom.xml
@@ -105,7 +105,6 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/examples/helidon-car-booking/pom.xml
+++ b/examples/helidon-car-booking/pom.xml
@@ -35,6 +35,14 @@
     </dependencyManagement>
 
     <dependencies>
+    	<dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>mp-ai-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>mp-ai-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>mp-ai-api</artifactId>

--- a/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -11,9 +11,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryMaxMessages = 5,
-
-        chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryMaxMessages = 5, chatLanguageModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -42,7 +42,7 @@
                 <version>${jakartaee-api.version}</version>
                 <scope>provided</scope>
             </dependency>
-			
+
             <dependency>
                 <groupId>org.eclipse.microprofile</groupId>
                 <artifactId>microprofile</artifactId>
@@ -103,8 +103,7 @@
             <groupId>io.smallrye.llm</groupId>
             <artifactId>mp-ai-api</artifactId>
         </dependency>
-		
-		
+
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>

--- a/examples/quarkus-car-booking/pom.xml
+++ b/examples/quarkus-car-booking/pom.xml
@@ -35,6 +35,15 @@
     </dependencyManagement>
 
     <dependencies>
+    	<dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>mp-ai-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>mp-ai-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>mp-ai-api</artifactId>

--- a/smallrye-llm-langchain4j-core/pom.xml
+++ b/smallrye-llm-langchain4j-core/pom.xml
@@ -11,6 +11,15 @@
     <name>SmallRye LLM: LangChain4j Core</name>
 
     <dependencies>
+    	<dependency>
+    		<groupId>io.smallrye.llm</groupId>
+        	<artifactId>mp-ai-api</artifactId>
+        	<version>${project.version}</version>
+    	</dependency>
+        <dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>mp-ai-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>mp-ai-api</artifactId>


### PR DESCRIPTION
Registering AI services factories to use SmallRye default factories instead of Langchain4J default services. Update Liberty example to include MP AI annotations instead of Langchain4J annotations, All examples now run with the MP annotations instead of Langchain4J annotations.