### PR TITLE
Cleaning dependencies in examples for simpler upgrade.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@ buildNumber.properties
 .classpath
 
 .idea
-
+nb-configuration.xml
 

--- a/examples/glassfish-car-booking/pom.xml
+++ b/examples/glassfish-car-booking/pom.xml
@@ -28,7 +28,6 @@
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.enterprise</groupId>
@@ -59,36 +58,30 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         <!-- langchain4j dependencies -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <!-- SLF4J messages from langchain4j and Azure OpenAI SDK backed by JUL -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
             <scope>runtime</scope>
-            <version>2.0.9</version>
         </dependency>
     </dependencies>
     <build>

--- a/examples/helidon-car-booking-portable-ext/pom.xml
+++ b/examples/helidon-car-booking-portable-ext/pom.xml
@@ -12,7 +12,6 @@
 
     <properties>
         <mainClass>io.helidon.Main</mainClass>
-        <dev.langchain4j.version>0.34.0</dev.langchain4j.version>
     </properties>
 
     <dependencyManagement>
@@ -20,14 +19,14 @@
             <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-bom</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-dependencies</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -38,12 +37,10 @@
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <!-- Adds all features available in MicroProfile -->
         <dependency>
@@ -96,35 +93,29 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         <!-- langchain4j dependencies -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <!-- Avoid ClassNotFoundException com.azure.xml.XmlProviders -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
-            <version>1.0.0-beta.3</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/examples/helidon-car-booking/pom.xml
+++ b/examples/helidon-car-booking/pom.xml
@@ -20,14 +20,14 @@
             <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-bom</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-dependencies</artifactId>
-                <version>4.0.7</version>
+                <version>4.0.12</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -38,12 +38,10 @@
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <!-- Adds all features available in MicroProfile -->
         <dependency>
@@ -100,7 +98,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         <!-- langchain4j dependencies -->
@@ -111,23 +108,19 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <!-- Avoid ClassNotFoundException com.azure.xml.XmlProviders -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
-            <version>1.0.0-beta.3</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -1,176 +1,121 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-  	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>io.smallrye.llm.examples</groupId>
-		<artifactId>examples</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
-	</parent>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.smallrye.llm.examples</groupId>
+        <artifactId>examples</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
 
-  	<artifactId>liberty-car-booking</artifactId>
-  	<packaging>war</packaging>
-	<name>SmallRye LLM Examples: Liberty Car Booking</name>
+    <artifactId>liberty-car-booking</artifactId>
+    <packaging>war</packaging>
+    <name>SmallRye LLM Examples: Liberty Car Booking</name>
 
-	<developers>
-		<developer>
-			<name>Buhake Sindi</name>
-			<timezone>+2</timezone>
-		</developer>
-	</developers>
+    <developers>
+        <developer>
+            <name>Buhake Sindi</name>
+            <timezone>+2</timezone>
+        </developer>
+    </developers>
 	
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.report.sourceEncoding>UTF-8</project.report.sourceEncoding>
-		<jakartaee-api.version>10.0.0</jakartaee-api.version>
-		<microprofile-api.version>6.1</microprofile-api.version>
-		<compiler-plugin.version>3.13.0</compiler-plugin.version>
-		<war-plugin.version>3.4.0</war-plugin.version>
-		<dev.langchain4j.version>0.34.0</dev.langchain4j.version>
-
-		<!--Strictly for OpenLiberty-->
-		<liberty.env.ENGINE_CACHE_DIR>${project.build.directory}/liberty/wlp/usr/shared/resources/lib/</liberty.env.ENGINE_CACHE_DIR>
-	</properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.report.sourceEncoding>UTF-8</project.report.sourceEncoding>
+        <jakartaee-api.version>10.0.0</jakartaee-api.version>
+        <microprofile-api.version>6.1</microprofile-api.version>
+        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <war-plugin.version>3.4.0</war-plugin.version>
+        <!--Strictly for OpenLiberty-->
+        <liberty.env.ENGINE_CACHE_DIR>${project.build.directory}/liberty/wlp/usr/shared/resources/lib/</liberty.env.ENGINE_CACHE_DIR>
+    </properties>
 	
-	<dependencyManagement>
-		<dependencies>
-		<!-- https://mvnrepository.com/artifact/jakarta.platform/jakarta.jakartaee-api -->
-			<dependency>
-				<groupId>jakarta.platform</groupId>
-				<artifactId>jakarta.jakartaee-api</artifactId>
-				<version>${jakartaee-api.version}</version>
-				<scope>provided</scope>
-			</dependency>
+    <dependencyManagement>
+        <dependencies>
+            <!-- https://mvnrepository.com/artifact/jakarta.platform/jakarta.jakartaee-api -->
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <version>${jakartaee-api.version}</version>
+                <scope>provided</scope>
+            </dependency>
 			
-			<dependency>
-				<groupId>org.eclipse.microprofile</groupId>
-				<artifactId>microprofile</artifactId>
-				<version>${microprofile-api.version}</version>
-				<type>pom</type>
-				<scope>provided</scope>
-			</dependency>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile</artifactId>
+                <version>${microprofile-api.version}</version>
+                <type>pom</type>
+                <scope>provided</scope>
+            </dependency>
 			
-			<!--
-			<dependency>
-				<groupId>io.smallrye.llm.liberty-bundle</groupId>
-				<artifactId>smallrye-llm-langchain4j-features-bom</artifactId>
-				<version>1.0.0-SNAPSHOT</version>
-				<type>pom</type>
-			</dependency>
-			-->
-			
-	        <dependency>
-	            <groupId>io.smallrye.llm</groupId>
-	            <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
-	            <version>1.0.0-SNAPSHOT</version>
-	        </dependency>
+            <!--
+            <dependency>
+                    <groupId>io.smallrye.llm.liberty-bundle</groupId>
+                    <artifactId>smallrye-llm-langchain4j-features-bom</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+                    <type>pom</type>
+            </dependency>
+            -->
+            <!--
+            <dependency>
+                    <groupId>io.smallrye.llm</groupId>
+                    <artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
+                    <version>1.0.0-SNAPSHOT</version>
+            </dependency>
+            -->
+            <!-- https://mvnrepository.com/artifact/ai.djl.huggingface/tokenizers -->
+            <dependency>
+                <groupId>ai.djl.huggingface</groupId>
+                <artifactId>tokenizers</artifactId>
+                <version>0.30.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-			<dependency>
-				<groupId>io.smallrye.llm</groupId>
-				<artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
-				<version>1.0.0-SNAPSHOT</version>
-			</dependency>
-			<!--
-			<dependency>
-				<groupId>io.smallrye.llm</groupId>
-			 	<artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
-			 	<version>1.0.0-SNAPSHOT</version>
-			</dependency>
-			-->
-			
-	        <dependency>
-	            <groupId>dev.langchain4j</groupId>
-	            <artifactId>langchain4j</artifactId>
-	            <version>${dev.langchain4j.version}</version>
-	        </dependency>
-	        
-	         <dependency>
-	            <groupId>dev.langchain4j</groupId>
-	            <artifactId>langchain4j-hugging-face</artifactId>
-	            <version>${dev.langchain4j.version}</version>
-	        </dependency>
-	        
-	        <!-- https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-azure-open-ai -->
-			<dependency>
-			    <groupId>dev.langchain4j</groupId>
-			    <artifactId>langchain4j-azure-open-ai</artifactId>
-			    <version>${dev.langchain4j.version}</version>
-			</dependency>
-			
-	        <dependency>
-	            <groupId>dev.langchain4j</groupId>
-	            <artifactId>langchain4j-open-ai</artifactId>
-	            <version>${dev.langchain4j.version}</version>
-	        </dependency>
-	        
-	        <dependency>
-	            <groupId>dev.langchain4j</groupId>
-	            <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-	            <version>${dev.langchain4j.version}</version>
-	        </dependency>
-        
-	        <!-- https://mvnrepository.com/artifact/ai.djl.huggingface/tokenizers -->
-			<dependency>
-			    <groupId>ai.djl.huggingface</groupId>
-			    <artifactId>tokenizers</artifactId>
-			    <version>0.30.0</version>
-			</dependency>
-	        
-	        <!-- SLF4J messages from langchain4j and Azure OpenAI SDK backed by JUL -->
-	        <dependency>
-	            <groupId>org.slf4j</groupId>
-	            <artifactId>slf4j-jdk14</artifactId>
-	            <scope>runtime</scope>
-	            <version>2.0.9</version>
-	        </dependency>
-		</dependencies>
-	</dependencyManagement>
-
-	<dependencies>
-		<!-- https://mvnrepository.com/artifact/jakarta.platform/jakarta.jakartaee-api -->
-		<!--
-		<dependency>
-			<groupId>jakarta.platform</groupId>
-			<artifactId>jakarta.jakartaee-api</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		-->
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/jakarta.platform/jakarta.jakartaee-api -->
+        <!--
+        <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-api</artifactId>
+                <scope>provided</scope>
+        </dependency>
+        -->
 		
-		<dependency>
-			<groupId>org.eclipse.microprofile</groupId>
-			<artifactId>microprofile</artifactId>
-			<type>pom</type>
-		</dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile</groupId>
+            <artifactId>microprofile</artifactId>
+            <type>pom</type>
+        </dependency>
 		
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
         </dependency>
 		
-		<dependency>
-			<groupId>io.smallrye.llm</groupId>
-			<artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>io.smallrye.llm</groupId>
+            <artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
+        </dependency>
 		
-		<!--		
-		<dependency>
-			<groupId>io.smallrye.llm</groupId>
-		 	<artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
-		</dependency>
-		-->
+        <!--		
+        <dependency>
+                <groupId>io.smallrye.llm</groupId>
+                <artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
+        </dependency>
+        -->
 		
-		<!--
-		<dependency>
-			<groupId>io.smallrye.llm.liberty-bundle</groupId>
-			<artifactId>smallrye-llm-langchain4j-feature</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
-			<type>pom</type>
-			<scope>provided</scope>
-		</dependency>
-		-->
+        <!--
+        <dependency>
+                <groupId>io.smallrye.llm.liberty-bundle</groupId>
+                <artifactId>smallrye-llm-langchain4j-feature</artifactId>
+                <version>1.0.0-SNAPSHOT</version>
+                <type>pom</type>
+                <scope>provided</scope>
+        </dependency>
+        -->
 		
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
             <scope>provided</scope>
         </dependency>
         
@@ -186,10 +131,10 @@
         </dependency>
         
         <!-- https://mvnrepository.com/artifact/dev.langchain4j/langchain4j-azure-open-ai -->
-		<dependency>
-		    <groupId>dev.langchain4j</groupId>
-		    <artifactId>langchain4j-azure-open-ai</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-azure-open-ai</artifactId>
+        </dependency>
 		
         <dependency>
             <groupId>dev.langchain4j</groupId>
@@ -202,10 +147,10 @@
         </dependency>
         
         <!-- https://mvnrepository.com/artifact/ai.djl.huggingface/tokenizers -->
-		<dependency>
-		    <groupId>ai.djl.huggingface</groupId>
-		    <artifactId>tokenizers</artifactId>
-		</dependency>
+        <dependency>
+            <groupId>ai.djl.huggingface</groupId>
+            <artifactId>tokenizers</artifactId>
+        </dependency>
         
         <!-- SLF4J messages from langchain4j and Azure OpenAI SDK backed by JUL -->
         <dependency>
@@ -213,43 +158,43 @@
             <artifactId>slf4j-jdk14</artifactId>
             <scope>runtime</scope>
         </dependency>
-	</dependencies>
+    </dependencies>
 	
-	<build>
-		<finalName>${project.artifactId}</finalName>
-		<pluginManagement>
-			<plugins>
-				<!-- https://mvnrepository.com/artifact/io.openliberty.tools/liberty-maven-plugin -->
-				<plugin>
-					<groupId>io.openliberty.tools</groupId>
-					<artifactId>liberty-maven-plugin</artifactId>
-					<version>3.10.3</version>
-					<configuration>
-						<bootstrapProperties>
-							<project.name>${project.build.finalName}</project.name>
-							<docragdir>${project.basedir}/docs-for-rag</docragdir>
-						</bootstrapProperties>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <pluginManagement>
+            <plugins>
+                <!-- https://mvnrepository.com/artifact/io.openliberty.tools/liberty-maven-plugin -->
+                <plugin>
+                    <groupId>io.openliberty.tools</groupId>
+                    <artifactId>liberty-maven-plugin</artifactId>
+                    <version>3.10.3</version>
+                    <configuration>
+                        <bootstrapProperties>
+                            <project.name>${project.build.finalName}</project.name>
+                            <docragdir>${project.basedir}/docs-for-rag</docragdir>
+                        </bootstrapProperties>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
 			
-			<plugin>
-				<groupId>io.openliberty.tools</groupId>
-				<artifactId>liberty-maven-plugin</artifactId>
-			</plugin>
+            <plugin>
+                <groupId>io.openliberty.tools</groupId>
+                <artifactId>liberty-maven-plugin</artifactId>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-war-plugin</artifactId>
-				<version>${war-plugin.version}</version>
-			</plugin>
-		</plugins>
-	</build>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${war-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,4 +19,71 @@
         <module>glassfish-car-booking</module>
         <module>liberty-car-booking</module>
     </modules>
+
+    <properties>
+        <dev.langchain4j.version>0.36.2</dev.langchain4j.version>
+    </properties>
+ 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.smallrye.llm</groupId>
+                <artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.llm</groupId>
+                <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.smallrye.llm</groupId>
+                <artifactId>smallrye-llm-langchain4j-portable-extension</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.36</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j</artifactId>
+                <version>${dev.langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-azure-open-ai</artifactId>
+                <version>${dev.langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
+                <version>${dev.langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-hugging-face</artifactId>
+                <version>${dev.langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-open-ai</artifactId>
+                <version>${dev.langchain4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.azure</groupId>
+                <artifactId>azure-xml</artifactId>
+                <version>1.0.0-beta.3</version>
+                <scope>runtime</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>2.0.16</version>
+                <scope>runtime</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/examples/quarkus-car-booking/pom.xml
+++ b/examples/quarkus-car-booking/pom.xml
@@ -16,7 +16,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.8.5</quarkus.platform.version>
+        <quarkus.platform.version>3.8.6</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
     </properties>
@@ -37,44 +37,36 @@
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-buildcompatible-extension</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.smallrye.llm</groupId>
             <artifactId>smallrye-llm-langchain4j-config-mpconfig</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.32</version>
         </dependency>
         <!-- langchain4j dependencies -->
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-hugging-face</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-azure-open-ai</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-embeddings-all-minilm-l6-v2</artifactId>
-            <version>${dev.langchain4j.version}</version>
         </dependency>
         <!-- Avoid ClassNotFoundException com.azure.xml.XmlProviders -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-xml</artifactId>
-            <version>1.0.0-beta.3</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -113,7 +105,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.1.8</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- ~  Copyright 2017 Red Hat, Inc.
- ~
- ~  Licensed under the Apache License, Version 2.0 (the "License");
- ~  you may not use this file except in compliance with the License.
- ~  You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~  Unless required by applicable law or agreed to in writing, software
- ~  distributed under the License is distributed on an "AS IS" BASIS,
- ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- ~  See the License for the specific language governing permissions and
- ~  limitations under the License.
-  -->
+~  Copyright 2017 Red Hat, Inc.
+~
+~  Licensed under the Apache License, Version 2.0 (the "License");
+~  you may not use this file except in compliance with the License.
+~  You may obtain a copy of the License at
+~
+~    http://www.apache.org/licenses/LICENSE-2.0
+~
+~  Unless required by applicable law or agreed to in writing, software
+~  distributed under the License is distributed on an "AS IS" BASIS,
+~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~  See the License for the specific language governing permissions and
+~  limitations under the License.
+-->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -35,14 +35,14 @@
 
     <properties>
         <version.eclipse.microprofile.config>3.1</version.eclipse.microprofile.config>
-        <version.smallrye.common>2.4.0</version.smallrye.common>
+        <version.smallrye.common>2.9.0</version.smallrye.common>
         <version.asm>9.7</version.asm>
-        <version.smallrye.testing>2.3.0</version.smallrye.testing>
+        <version.smallrye.testing>2.3.1</version.smallrye.testing>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
-        <weld-junit5.version>4.0.0.Final</weld-junit5.version>
+        <weld-junit5.version>4.0.3.Final</weld-junit5.version>
         <version.weld>5.1.3.Final</version.weld>
         <version.org.jboss.logging>3.5.3.Final</version.org.jboss.logging>
-        <dev.langchain4j.version>0.34.0</dev.langchain4j.version>
+        <dev.langchain4j.version>0.36.1</dev.langchain4j.version>
 
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.source>17</maven.compiler.source>
@@ -141,19 +141,19 @@
         </dependencies>
     </dependencyManagement>
     
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
 			
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
         </plugins>
-	</build>
+    </build>
 
     <profiles>
         <profile>

--- a/smallrye-llm-langchain4j-config-mpconfig/src/main/java/io/smallrye/llm/core/langchain4j/mpconfig/LLMConfigMPConfig.java
+++ b/smallrye-llm-langchain4j-config-mpconfig/src/main/java/io/smallrye/llm/core/langchain4j/mpconfig/LLMConfigMPConfig.java
@@ -2,6 +2,7 @@ package io.smallrye.llm.core.langchain4j.mpconfig;
 
 import static io.smallrye.llm.core.langchain4j.core.config.spi.LLMConfig.getBeanPropertyName;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -36,7 +37,7 @@ public class LLMConfigMPConfig implements LLMConfig {
 
     @Override
     public Set<String> getBeanNames() {
-        return beanNames;
+        return Collections.unmodifiableSet(beanNames);
     }
 
     @Override

--- a/smallrye-llm-langchain4j-portable-extension/src/main/java/io/smallrye/llm/core/langchain4j/portableextension/LangChain4JPluginsPortableExtension.java
+++ b/smallrye-llm-langchain4j-portable-extension/src/main/java/io/smallrye/llm/core/langchain4j/portableextension/LangChain4JPluginsPortableExtension.java
@@ -21,13 +21,14 @@ public class LangChain4JPluginsPortableExtension implements Extension {
 
     void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager)
             throws ClassNotFoundException {
-        if (llmConfig == null)
+        if (llmConfig == null) {
             llmConfig = LLMConfigProvider.getLlmConfig();
+        }
 
         CommonLLMPluginCreator.createAllLLMBeans(
                 llmConfig,
                 beanData -> {
-                    LOGGER.info("Add Bean " + beanData.getTargetClass() + " " + beanData.getScopeClass() + " "
+                    LOGGER.debug("Add Bean " + beanData.getTargetClass() + " " + beanData.getScopeClass() + " "
                             + beanData.getBeanName());
 
                     afterBeanDiscovery.addBean()


### PR DESCRIPTION
Moving traces down a level to be less verbose.
Upgrading lombok from 1.18.32 to 1.18.36
Upgrading langchain4j from 0.34.0 to 0.36.2
Upgrading sl4fj from 2.0.9 to 2.0.16
Upgrading jandex maven plugin from 3.1.2 to 3.1.8
Upgrading helidon from 4.0.7 to 4.0.12