### PR TITLE
Upgrading LangChain4J core to 1.0.0-rc1 and LangChain4J modules to

### DIFF
--- a/examples/glassfish-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
@@ -3,10 +3,9 @@ package io.jefrajames.booking;
 import dev.langchain4j.service.SystemMessage;
 import io.smallrye.llm.spi.RegisterAIService;
 
-import java.time.temporal.ChronoUnit;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatModelName = "chat-model")
 public interface ChatAiService {
 
     @SystemMessage("""

--- a/examples/glassfish-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -6,7 +6,7 @@ import dev.langchain4j.service.V;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/helidon-car-booking-portable-ext/src/main/java/io/jefrajames/booking/ChatAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/io/jefrajames/booking/ChatAiService.java
@@ -10,7 +10,7 @@ import dev.langchain4j.service.SystemMessage;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatModelName = "chat-model")
 public interface ChatAiService {
 
     @SystemMessage("""

--- a/examples/helidon-car-booking-portable-ext/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -12,7 +12,7 @@ import dev.langchain4j.service.V;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
+++ b/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
@@ -10,7 +10,7 @@ import dev.langchain4j.service.SystemMessage;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatModelName = "chat-model")
 public interface ChatAiService {
 
     @SystemMessage("""

--- a/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/helidon-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -12,7 +12,7 @@ import dev.langchain4j.service.V;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/liberty-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/liberty-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -11,7 +11,7 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import io.smallrye.llm.spi.RegisterAIService;
 
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/payara-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
+++ b/examples/payara-car-booking/src/main/java/io/jefrajames/booking/ChatAiService.java
@@ -3,10 +3,9 @@ package io.jefrajames.booking;
 import dev.langchain4j.service.SystemMessage;
 import io.smallrye.llm.spi.RegisterAIService;
 
-import java.time.temporal.ChronoUnit;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory", chatModelName = "chat-model")
 public interface ChatAiService {
 
     @SystemMessage("""

--- a/examples/payara-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
+++ b/examples/payara-car-booking/src/main/java/io/jefrajames/booking/FraudAiService.java
@@ -6,7 +6,7 @@ import dev.langchain4j.service.V;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatLanguageModelName = "chat-model")
+@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage("""

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -51,7 +51,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j</artifactId>
-                <version>${dev.langchain4j.version}</version>
+                <version>${dev.langchain4j.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.langchain4j</groupId>
@@ -71,7 +71,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-open-ai</artifactId>
-                <version>${dev.langchain4j.version}</version>
+                <version>${dev.langchain4j.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.djl.huggingface</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dev.langchain4j.version>1.0.0-beta3</dev.langchain4j.version>
+        <dev.langchain4j.core.version>1.0.0-rc1</dev.langchain4j.core.version>
+        <dev.langchain4j.version>1.0.0-beta4</dev.langchain4j.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
 
@@ -112,6 +113,12 @@
                 <type>pom</type>
             </dependency>
             <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bom</artifactId>
+                <version>${dev.langchain4j.core.version}</version>
+                <type>pom</type>
+            </dependency>
+            <dependency>
                 <groupId>io.smallrye.common</groupId>
                 <artifactId>smallrye-common-bom</artifactId>
                 <version>${version.smallrye.common}</version>
@@ -159,7 +166,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j</artifactId>
-                <version>${dev.langchain4j.version}</version>
+                <version>${dev.langchain4j.core.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.smallrye.llm</groupId>

--- a/smallrye-llm-langchain4j-buildcompatible-extension/src/test/java/io/smallrye/llm/core/BceExtensionTest.java
+++ b/smallrye-llm-langchain4j-buildcompatible-extension/src/test/java/io/smallrye/llm/core/BceExtensionTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import io.smallrye.config.inject.ConfigExtension;
 import io.smallrye.llm.aiservice.Langchain4JAIServiceBuildCompatibleExtension;
 
@@ -34,7 +34,7 @@ public class BceExtensionTest {
     RequestContextCaller requestContextCaller;
 
     @Inject
-    ChatLanguageModel chatLanguageModel;
+    ChatModel chatLanguageModel;
 
     @Inject
     BeanManager beanManager;
@@ -44,7 +44,7 @@ public class BceExtensionTest {
             MyDummyAIService.class,
             MyDummyApplicationScopedAIService.class,
             RequestContextCaller.class,
-            DummyChatLanguageModel.class,
+            DummyChatModel.class,
             DummyEmbeddingStore.class,
             DummyEmbeddingModel.class,
             ConfigExtension.class)
@@ -52,9 +52,9 @@ public class BceExtensionTest {
 
     @Test
     public void assertPlugin() {
-        Assertions.assertEquals(((DummyChatLanguageModel) chatLanguageModel).getApiKey(), "apikey");
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel());
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel2());
+        Assertions.assertEquals(((DummyChatModel) chatLanguageModel).getApiKey(), "apikey");
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel());
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel2());
     }
 
     @Test

--- a/smallrye-llm-langchain4j-buildcompatible-extension/src/test/java/io/smallrye/llm/core/DummyChatModel.java
+++ b/smallrye-llm-langchain4j-buildcompatible-extension/src/test/java/io/smallrye/llm/core/DummyChatModel.java
@@ -4,16 +4,16 @@ import java.util.List;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 
-public class DummyChatLanguageModel implements ChatLanguageModel {
+public class DummyChatModel implements ChatModel {
     private String apiKey;
     private EmbeddingModel embeddingModel;
     private EmbeddingModel embeddingModel2;
 
-    public DummyChatLanguageModel(String apiKey, EmbeddingModel embeddingModel, EmbeddingModel embeddingModel2) {
+    public DummyChatModel(String apiKey, EmbeddingModel embeddingModel, EmbeddingModel embeddingModel2) {
         this.apiKey = apiKey;
         this.embeddingModel = embeddingModel;
         this.embeddingModel2 = embeddingModel2;
@@ -44,8 +44,8 @@ public class DummyChatLanguageModel implements ChatLanguageModel {
         private EmbeddingModel embeddingModel;
         private EmbeddingModel embeddingModel2;
 
-        public DummyChatLanguageModel build() {
-            return new DummyChatLanguageModel(this.apiKey, this.embeddingModel, this.embeddingModel2);
+        public DummyChatModel build() {
+            return new DummyChatModel(this.apiKey, this.embeddingModel, this.embeddingModel2);
         }
 
         public void embeddingModel2(EmbeddingModel embeddingModel) {

--- a/smallrye-llm-langchain4j-buildcompatible-extension/src/test/resources/META-INF/microprofile-config.properties
+++ b/smallrye-llm-langchain4j-buildcompatible-extension/src/test/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,4 @@
-smallrye.llm.plugin.chat-model-dummy.class=io.smallrye.llm.core.DummyChatLanguageModel
+smallrye.llm.plugin.chat-model-dummy.class=io.smallrye.llm.core.DummyChatModel
 smallrye.llm.plugin.chat-model-dummy.config.api-key=apikey
 smallrye.llm.plugin.chat-model-dummy.config.embedding-model=lookup:myModel
 smallrye.llm.plugin.chat-model-dummy.config.embedding-model2=lookup:default

--- a/smallrye-llm-langchain4j-core/src/main/java/io/smallrye/llm/plugin/CommonLLMPluginCreator.java
+++ b/smallrye-llm-langchain4j-core/src/main/java/io/smallrye/llm/plugin/CommonLLMPluginCreator.java
@@ -24,8 +24,8 @@ import jakarta.enterprise.util.TypeLiteral;
 import org.jboss.logging.Logger;
 
 import dev.langchain4j.data.segment.TextSegment;
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.chat.StreamingChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.listener.ChatModelListener;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import io.smallrye.llm.core.langchain4j.core.config.spi.LLMConfig;
@@ -153,8 +153,8 @@ public class CommonLLMPluginCreator {
                     for (Method methodToCall : methodsToCall) {
                         Class<?> parameterType = methodToCall.getParameterTypes()[0];
                         if ("listeners".equals(property)) {
-                            Class<?> typeParameterClass = ChatLanguageModel.class.isAssignableFrom(targetClass)
-                                    || StreamingChatLanguageModel.class.isAssignableFrom(targetClass)
+                            Class<?> typeParameterClass = ChatModel.class.isAssignableFrom(targetClass)
+                                    || StreamingChatModel.class.isAssignableFrom(targetClass)
                                             ? ChatModelListener.class
                                             : parameterType.getTypeParameters()[0].getGenericDeclaration();
                             List<Object> listeners = (List<Object>) Collections.checkedList(new ArrayList<>(),

--- a/smallrye-llm-langchain4j-core/src/main/java/io/smallrye/llm/spi/RegisterAIService.java
+++ b/smallrye-llm-langchain4j-core/src/main/java/io/smallrye/llm/spi/RegisterAIService.java
@@ -19,9 +19,15 @@ public @interface RegisterAIService {
 
     Class<?>[] tools() default {};
 
+    @Deprecated
     String chatLanguageModelName() default "#default";
 
+    @Deprecated
     String streamingChatLanguageModelName() default "";
+
+    String chatModelName() default "#default";
+
+    String streamingChatModelName() default "";
 
     String contentRetrieverName() default "";
 

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-common/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatAiService.java
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-common/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatAiService.java
@@ -4,7 +4,7 @@ import dev.langchain4j.service.SystemMessage;
 import io.smallrye.llm.spi.RegisterAIService;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatLanguageModelName = "chat-model")
+@RegisterAIService(chatModelName = "chat-model")
 public interface ChatAiService {
 
     @SystemMessage("""

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-helidon/pom.xml
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-helidon/pom.xml
@@ -41,13 +41,12 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
-            <version>3.1.2.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
-            <version>${dev.langchain4j.version}</version> <!-- We MUST force the version because helidon embed a previous version -->
+            <version>${dev.langchain4j.core.version}</version> <!-- We MUST force the version because helidon embed a previous version -->
         </dependency>
         <!-- Logging dependency -->
         <dependency>

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-helidon/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-helidon/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
@@ -3,13 +3,13 @@ package io.smallrye.llm.core.langchain4j.integrationtests;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 
 @ApplicationScoped
-public class ChatModelMock implements ChatLanguageModel {
+public class ChatModelMock implements ChatModel {
 
     private ChatResponse fixedChatResponse;
 

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-jakartaee/pom.xml
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-jakartaee/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${dev.langchain4j.version}</version>
+            <version>${dev.langchain4j.core.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-jakartaee/smallrye-llm-langchain4j-integration-tests-jakartaee-common-wildfly/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-jakartaee/smallrye-llm-langchain4j-integration-tests-jakartaee-common-wildfly/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
@@ -3,13 +3,13 @@ package io.smallrye.llm.core.langchain4j.integrationtests;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 
 @ApplicationScoped
-public class ChatModelMock implements ChatLanguageModel {
+public class ChatModelMock implements ChatModel {
 
     private ChatResponse fixedChatResponse;
 

--- a/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-quarkus/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
+++ b/smallrye-llm-langchain4j-integration-tests/smallrye-llm-langchain4j-integration-tests-quarkus/src/main/java/io/smallrye/llm/core/langchain4j/integrationtests/ChatModelMock.java
@@ -3,13 +3,13 @@ package io.smallrye.llm.core.langchain4j.integrationtests;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import dev.langchain4j.data.message.AiMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 
 @ApplicationScoped
-public class ChatModelMock implements ChatLanguageModel {
+public class ChatModelMock implements ChatModel {
 
     private ChatResponse fixedChatResponse;
 

--- a/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/DummyChatModel.java
+++ b/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/DummyChatModel.java
@@ -4,16 +4,16 @@ import java.util.List;
 
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.embedding.EmbeddingModel;
 import dev.langchain4j.model.output.Response;
 
-public class DummyChatLanguageModel implements ChatLanguageModel {
+public class DummyChatModel implements ChatModel {
     private String apiKey;
     private EmbeddingModel embeddingModel;
     private EmbeddingModel embeddingModel2;
 
-    public DummyChatLanguageModel(String apiKey, EmbeddingModel embeddingModel, EmbeddingModel embeddingModel2) {
+    public DummyChatModel(String apiKey, EmbeddingModel embeddingModel, EmbeddingModel embeddingModel2) {
         this.apiKey = apiKey;
         this.embeddingModel = embeddingModel;
         this.embeddingModel2 = embeddingModel2;
@@ -44,8 +44,8 @@ public class DummyChatLanguageModel implements ChatLanguageModel {
         private EmbeddingModel embeddingModel;
         private EmbeddingModel embeddingModel2;
 
-        public DummyChatLanguageModel build() {
-            return new DummyChatLanguageModel(this.apiKey, this.embeddingModel, this.embeddingModel2);
+        public DummyChatModel build() {
+            return new DummyChatModel(this.apiKey, this.embeddingModel, this.embeddingModel2);
         }
 
         public void embeddingModel2(EmbeddingModel embeddingModel) {

--- a/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/PortableExtensionInstanceTest.java
+++ b/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/PortableExtensionInstanceTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import io.smallrye.config.inject.ConfigExtension;
 import io.smallrye.llm.core.langchain4j.portableextension.LangChain4JAIServicePortableExtension;
 import io.smallrye.llm.core.langchain4j.portableextension.LangChain4JPluginsPortableExtension;
@@ -36,7 +36,7 @@ public class PortableExtensionInstanceTest {
     RequestContextCaller requestContextCaller;
 
     @Inject
-    ChatLanguageModel chatLanguageModel;
+    ChatModel chatLanguageModel;
 
     @Inject
     BeanManager beanManager;
@@ -48,7 +48,7 @@ public class PortableExtensionInstanceTest {
             MyDummyAIService.class,
             MyDummyApplicationScopedAIService.class,
             RequestContextCaller.class,
-            DummyChatLanguageModel.class,
+            DummyChatModel.class,
             DummyEmbeddingStore.class,
             DummyEmbeddingModel.class,
             ConfigExtension.class)
@@ -56,9 +56,9 @@ public class PortableExtensionInstanceTest {
 
     @Test
     public void assertPlugin() {
-        Assertions.assertEquals(((DummyChatLanguageModel) chatLanguageModel).getApiKey(), "apikey");
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel());
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel2());
+        Assertions.assertEquals(((DummyChatModel) chatLanguageModel).getApiKey(), "apikey");
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel());
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel2());
     }
 
     @Test

--- a/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/PortableExtensionTest.java
+++ b/smallrye-llm-langchain4j-portable-extension/src/test/java/io/smallrye/llm/core/PortableExtensionTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import io.smallrye.config.inject.ConfigExtension;
 import io.smallrye.llm.core.langchain4j.portableextension.LangChain4JAIServicePortableExtension;
 import io.smallrye.llm.core.langchain4j.portableextension.LangChain4JPluginsPortableExtension;
@@ -35,7 +35,7 @@ public class PortableExtensionTest {
     RequestContextCaller requestContextCaller;
 
     @Inject
-    ChatLanguageModel chatLanguageModel;
+    ChatModel chatLanguageModel;
 
     @Inject
     BeanManager beanManager;
@@ -47,7 +47,7 @@ public class PortableExtensionTest {
             MyDummyAIService.class,
             MyDummyApplicationScopedAIService.class,
             RequestContextCaller.class,
-            DummyChatLanguageModel.class,
+            DummyChatModel.class,
             DummyEmbeddingStore.class,
             DummyEmbeddingModel.class,
             ConfigExtension.class)
@@ -55,9 +55,9 @@ public class PortableExtensionTest {
 
     @Test
     public void assertPlugin() {
-        Assertions.assertEquals(((DummyChatLanguageModel) chatLanguageModel).getApiKey(), "apikey");
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel());
-        Assertions.assertNotNull(((DummyChatLanguageModel) chatLanguageModel).getEmbeddingModel2());
+        Assertions.assertEquals(((DummyChatModel) chatLanguageModel).getApiKey(), "apikey");
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel());
+        Assertions.assertNotNull(((DummyChatModel) chatLanguageModel).getEmbeddingModel2());
     }
 
     @Test

--- a/smallrye-llm-langchain4j-portable-extension/src/test/resources/META-INF/microprofile-config.properties
+++ b/smallrye-llm-langchain4j-portable-extension/src/test/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,4 @@
-smallrye.llm.plugin.chat-model-dummy.class=io.smallrye.llm.core.DummyChatLanguageModel
+smallrye.llm.plugin.chat-model-dummy.class=io.smallrye.llm.core.DummyChatModel
 smallrye.llm.plugin.chat-model-dummy.config.api-key=apikey
 smallrye.llm.plugin.chat-model-dummy.config.embedding-model=lookup:myModel
 smallrye.llm.plugin.chat-model-dummy.config.embedding-model2=lookup:default


### PR DESCRIPTION
1.0.0-beta4

* Compatibility breaks:
  - ChatlanguageModel is now ChatModel
  - StreamingChatLanguageModel is now StreamingChatModel
  - RegisterAIService chatLanguageModelName is renamed to chatModelName
  - RegisterAIService streamingChatLanguageModelName is renamed to streamingChatModelName